### PR TITLE
new assertions model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ repository = "https://github.com/aaronabramov/k9"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diff = "0.1.12"
 colored = "1.9.3"
+diff = "0.1.12"
+lazy_static = "1.4.0"
 regex = "1.3.7"
 
 [dev-dependencies]

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -1,4 +1,108 @@
+use crate::utils::add_linebreaks;
+use lazy_static::lazy_static;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 pub mod equal;
 pub mod err_matches_regex;
 pub mod matches_regex;
 pub mod matches_snapshot;
+
+lazy_static! {
+    /// This is an example for using doc comment attributes
+    static ref ASSERTIONS_WILL_PANIC: AtomicBool = { AtomicBool::new(true) };
+}
+
+pub fn set_panic(v: bool) {
+    ASSERTIONS_WILL_PANIC.store(v, Ordering::Relaxed)
+}
+
+pub fn should_panic() -> bool {
+    ASSERTIONS_WILL_PANIC.load(Ordering::Relaxed)
+}
+
+#[derive(Debug)]
+pub struct Assertion {
+    // Description of what's being asserted to provide a bit more context in the error mesasge
+    pub description: Option<String>,
+    pub failure_message: Option<String>,
+}
+
+impl Assertion {
+    pub fn assert(&self) -> Option<String> {
+        self.failure_message.as_ref().map(|failure_message| {
+            let message = format!(
+                "{description}{failure_message}",
+                description = self
+                    .description
+                    .as_ref()
+                    .map(|s| add_linebreaks(&s))
+                    .unwrap_or("".into()),
+                failure_message = failure_message,
+            );
+
+            if should_panic() {
+                panic!(message);
+            }
+            message
+        })
+    }
+}
+
+#[macro_export]
+macro_rules! make_assertion {
+    ($message:expr, $description:expr) => {{
+        if let Some(message) = $message {
+            ($crate::assertions::Assertion {
+                description: Some($description.into()),
+                failure_message: Some(message),
+            })
+            .assert()
+        } else {
+            None
+        }
+    }};
+    ($message:expr) => {{
+        if let Some(message) = $message {
+            ($crate::assertions::Assertion {
+                description: None,
+                failure_message: Some(message),
+            })
+            .assert()
+        } else {
+            None
+        }
+    }};
+}
+
+/// Asserts that two passed arguments are equal.
+/// panics if they are not
+///
+/// ```rust
+/// use k9::assert_equal;
+///
+/// // simple values
+/// assert_equal!(1, 1);
+///
+/// #[derive(Debug, PartialEq)]
+/// struct A {
+///     name: &'static str   
+/// }
+///
+/// let a1 = A { name: "Kelly" };
+/// let a2 = A { name: "Kelly" };
+///
+/// // this will print the visual difference between two structs
+/// assert_equal!(a1, a2);
+/// ```
+#[macro_export]
+macro_rules! assert_equal {
+    ($left:expr, $right:expr) => {{
+        $crate::make_assertion!($crate::assertions::equal::assert_equal($left, $right))
+    }};
+    ($left:expr, $right:expr, $description:expr) => {{
+        $crate::make_assertion!(
+            $crate::assertions::equal::assert_equal($left, $right),
+            $description
+        )
+    }};
+}

--- a/src/assertions/equal.rs
+++ b/src/assertions/equal.rs
@@ -5,85 +5,22 @@ use crate::Result;
 use colored::*;
 use std::fmt::Debug;
 
-/// Asserts that two passed arguments are equal.
-/// panics if they are not
-///
-/// ```rust
-/// use k9::assert_equal;
-///
-/// // simple values
-/// assert_equal!(1, 1);
-///
-/// #[derive(Debug, PartialEq)]
-/// struct A {
-///     name: &'static str   
-/// }
-///
-/// let a1 = A { name: "Kelly" };
-/// let a2 = A { name: "Kelly" };
-///
-/// // this will print the visual difference between two structs
-/// assert_equal!(a1, a2);
-/// ```
-#[macro_export]
-macro_rules! assert_equal {
-    ($left:expr, $right:expr) => {{
-        $crate::assert_equal_r!($left, $right).unwrap();
-    }};
-    ($left:expr, $right:expr, $context:expr) => {{
-        $crate::assert_equal_r!($left, $right, $context).unwrap();
-    }};
-}
-
-/// Same as `assert_equal!` but returns an assertion `Result` instead
-/// ```rust
-/// use k9::assert_equal_r;
-///
-/// fn give_me_a_number(s: &str) -> Result<u32, ParseIntError> {
-///    // parses the string into an integer
-///    return s.parse();
-/// }
-///
-/// let num_four = "4";
-/// let num_four_with_space = " 4";
-///
-/// // These should parse the string into the same integer: 4
-/// assert_equal_r!(give_me_a_number(num_four), give_me_a_number(num_four_with_space));
-/// ``
-#[macro_export]
-macro_rules! assert_equal_r {
-    ($left:expr, $right:expr) => {{
-        $crate::assertions::equal::assert_equal_impl($left, $right, None)
-    }};
-    ($left:expr, $right:expr, $context:expr) => {{
-        $crate::assertions::equal::assert_equal_impl($left, $right, Some($context))
-    }};
-}
-
-pub fn assert_equal_impl<T: Debug + PartialEq>(
-    left: T,
-    right: T,
-    context: Option<&str>,
-) -> Result<()> {
+pub fn assert_equal<T: Debug + PartialEq>(left: T, right: T) -> Option<String> {
     if left != right {
         let diff_string = colored_diff(&format!("{:#?}", &left), &format!("{:#?}", &right))
             .unwrap_or_else(|| "no visual difference between values".to_string());
 
         let message = format!(
             "
-{context}{assertion_desc}({left_desc}, {right_desc})
-
 Expected `{left_desc}` to equal `{right_desc}`:
 {diff_string}",
-            context = context.map(add_linebreaks).unwrap_or("".into()),
-            assertion_desc = "assert_equal!".dimmed(),
             left_desc = "Left".red(),
             right_desc = "Right".green(),
             diff_string = &diff_string
         );
 
-        Err(AssertionError::new(message))
+        Some(message)
     } else {
-        Ok(())
+        None
     }
 }

--- a/tests/assertions/__k9_snapshots__/equals_test/assertions_equals_test_multiline_struct_equality_test.snap
+++ b/tests/assertions/__k9_snapshots__/equals_test/assertions_equals_test_multiline_struct_equality_test.snap
@@ -1,6 +1,4 @@
 
-[2massert_equal![0m([31mLeft[0m, [32mRight[0m)
-
 Expected `[31mLeft[0m` to equal `[32mRight[0m`:
 
   [2mX {[0m

--- a/tests/assertions/__k9_snapshots__/equals_test/assertions_equals_test_test_assert_equal.snap
+++ b/tests/assertions/__k9_snapshots__/equals_test/assertions_equals_test_test_assert_equal.snap
@@ -1,6 +1,4 @@
 
-[2massert_equal![0m([31mLeft[0m, [32mRight[0m)
-
 Expected `[31mLeft[0m` to equal `[32mRight[0m`:
 
 [31m-[0m [31m1[0m

--- a/tests/assertions/__k9_snapshots__/equals_test/assertions_equals_test_with_context.snap
+++ b/tests/assertions/__k9_snapshots__/equals_test/assertions_equals_test_with_context.snap
@@ -1,7 +1,5 @@
 
-
 Expected those two things to be equal
-[2massert_equal![0m([31mLeft[0m, [32mRight[0m)
 
 Expected `[31mLeft[0m` to equal `[32mRight[0m`:
 

--- a/tests/assertions/equals_test.rs
+++ b/tests/assertions/equals_test.rs
@@ -1,20 +1,23 @@
 use anyhow::Result;
-use k9::{assert_equal, assert_equal_r, assert_matches_snapshot};
+use k9::{assert_equal, assert_matches_snapshot};
 
 #[test]
 fn test_assert_equal() -> Result<()> {
-    assert_equal!(1, 1);
-    assert_equal_r!("lol", &String::from("lol"))?;
+    k9::assertions::set_panic(false);
 
-    let err = assert_equal_r!(1, 2).unwrap_err();
-    assert_matches_snapshot!(err);
+    assert!(assert_equal!(1, 1).is_none());
+    assert!(assert_equal!("lol", &String::from("lol")).is_none());
 
-    assert_equal_r!(123, 123, "Expected two integers to be the same")?;
+    let failure_message = assert_equal!(1, 2).expect("must fail");
+    assert_matches_snapshot!(failure_message);
+
+    assert!(assert_equal!(123, 123, "Expected two integers to be the same").is_none());
     Ok(())
 }
 
 #[test]
 fn multiline_struct_equality_test() -> Result<()> {
+    k9::assertions::set_panic(false);
     #[derive(PartialEq, Debug)]
     struct X {
         a: String,
@@ -37,7 +40,7 @@ fn multiline_struct_equality_test() -> Result<()> {
         d: None,
     };
 
-    let err = assert_equal_r!(x1, x2).unwrap_err();
+    let err = assert_equal!(x1, x2).expect("must fail");
 
     assert_matches_snapshot!(err);
     Ok(())
@@ -45,6 +48,7 @@ fn multiline_struct_equality_test() -> Result<()> {
 
 #[test]
 fn with_context() {
-    let err = assert_equal_r!(1, 2, "Expected those two things to be equal").unwrap_err();
+    k9::assertions::set_panic(false);
+    let err = assert_equal!(1, 2, "Expected those two things to be equal").expect("must fail");
     assert_matches_snapshot!(err);
 }


### PR DESCRIPTION
new model for assertions that uses an `Assertion` struct and will be able to abstract away a lat of message composition that's shared between multiple assertions (like context, line numbers, codeframe, etc)