### PR TITLE
Enabled GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run tests
+      run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
-![Rust CI](https://github.com/TheWebDevel/k9/workflows/Rust%20CI/badge.svg)
+![Rust CI](https://github.com/aaronabramov/k9/workflows/Rust%20CI/badge.svg)
 
 [crates-badge]: https://img.shields.io/crates/v/k9.svg
 [crates-url]: https://crates.io/crates/k9

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
+![Rust CI](https://github.com/TheWebDevel/k9/workflows/Rust%20CI/badge.svg)
 
 [crates-badge]: https://img.shields.io/crates/v/k9.svg
 [crates-url]: https://crates.io/crates/k9

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
-![Rust CI](https://github.com/aaronabramov/k9/workflows/Rust%20CI/badge.svg)
+![Rust CI](https://github.com/TheWebDevel/k9/workflows/Rust%20CI/badge.svg)
 
 [crates-badge]: https://img.shields.io/crates/v/k9.svg
 [crates-url]: https://crates.io/crates/k9


### PR DESCRIPTION
Enabled GitHub Actions that Runs `cargo test --verbose` with the matrix strategy in 3 OS (`[ubuntu-latest, windows-latest, macOS-latest]`). I used matrix because we can also test on different Rust Versions on Different OS.

Here's a log from the Github Action
![image](https://user-images.githubusercontent.com/24741291/84584935-c75deb00-ae27-11ea-8129-06836031e109.png)

Badge
![image](https://user-images.githubusercontent.com/24741291/84584959-ef4d4e80-ae27-11ea-864c-b56b2ff12a12.png)

