### PR TITLE
Add feature toggle for 'regex' capability (default: enabled)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,10 @@ jobs:
         run: cargo test --verbose
 
       - uses: actions-rs/cargo@v1
+      - name: Run tests (without default features)
+        run: cargo test --no-default-features --verbose
+
+      - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,14 @@ license = "MIT"
 repository = "https://github.com/aaronabramov/k9"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["regex"]
 
 [dependencies]
 colored = "1.9.3"
 diff = "0.1.12"
 lazy_static = "1.4.0"
-regex = "1.3.7"
+regex = { version = "1.3.7", optional = true }
 term_size = "0.3.2"
 
 [dev-dependencies]

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -2,11 +2,13 @@ use crate::utils;
 use colored::*;
 
 pub mod equal;
+#[cfg(feature = "regex")]
 pub mod err_matches_regex;
 pub mod greater_than;
 pub mod greater_than_or_equal;
 pub mod lesser_than;
 pub mod lesser_than_or_equal;
+#[cfg(feature = "regex")]
 pub mod matches_regex;
 pub mod matches_snapshot;
 
@@ -308,6 +310,7 @@ macro_rules! assert_lesser_than_or_equal {
 /// assert_matches_regex!("1234-45", "\\d{4}-\\d{2}");
 /// assert_matches_regex!("abc", "abc");
 /// ````
+#[cfg(feature = "regex")]
 #[macro_export]
 macro_rules! assert_matches_regex {
     ($s:expr, $regex:expr) => {{
@@ -357,6 +360,7 @@ macro_rules! assert_matches_regex {
 /// let division_error = divide(4.0, 0.0);
 /// assert_err_matches_regex!(division_error, "Cannot");
 /// ```
+#[cfg(feature = "regex")]
 #[macro_export]
 macro_rules! assert_err_matches_regex {
     ($err:expr, $regex:expr) => {{

--- a/tests/assertions/mod.rs
+++ b/tests/assertions/mod.rs
@@ -1,9 +1,11 @@
 mod equals_test;
+#[cfg(feature = "regex")]
 mod err_matches_regex_test;
 mod greater_than_or_equal_test;
 mod greater_than_test;
 mod lesser_than_or_equal_test;
 mod lesser_than_test;
+#[cfg(feature = "regex")]
 mod matches_regex_test;
 mod matches_snapshot_test;
 


### PR DESCRIPTION
That way, those who don't need that functionality don't have to pay for it with increased compile times.

The timing difference for `cargo test` on a fresh build is 14.1s vs 3.7s on my machine.