### PR TITLE
README in crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 authors = ["Aaron Abramov <aaron@abramov.io>"]
 edition = "2018"
 description = "rust testing library"
+readme = "README.md"
 license = "MIT"
 repository = "https://github.com/aaronabramov/k9"
 


### PR DESCRIPTION
Added README.md reference to cargo.toml to reflect in crates.io

The README will be reflected when doing `cargo publish`