### PR TITLE
collapse large difference output

### DIFF
--- a/src/assertions/equal.rs
+++ b/src/assertions/equal.rs
@@ -6,7 +6,6 @@ pub fn assert_equal<T: Debug + PartialEq>(left: T, right: T) -> Option<String> {
     if left != right {
         let diff_string = colored_diff(&format!("{:#?}", &left), &format!("{:#?}", &right))
             .unwrap_or_else(|| "no visual difference between values".to_string());
-
         let message = format!(
             "
 Expected `{left_desc}` to equal `{right_desc}`:

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ pub struct Config {
     pub terminal_width_override: AtomicUsize,
     // Snapshot update mode
     pub update_mode: bool,
+    // Snapshot expand mode
+    pub expand_mode: bool,
 }
 
 lazy_static! {
@@ -15,6 +17,7 @@ lazy_static! {
         assertions_will_panic: AtomicBool::new(true),
         terminal_width_override: AtomicUsize::new(0),
         update_mode: is_update_mode(),
+        expand_mode: is_expand_mode(),
     };
 }
 
@@ -48,6 +51,25 @@ fn is_update_mode() -> bool {
         // NOTE: using compile time vars is a bit sketchy, because technically you can compile the test suite
         // once and re-run the compiled version multiple times in scenarious where you don't want to update
         if option_env!("K9_UPDATE_SNAPSHOTS").is_some() {
+            return true;
+        }
+    }
+
+    runtime_var
+}
+
+fn is_expand_mode() -> bool {
+    // If runtime ENV variable is set, it takes precedence
+    let runtime_var = std::env::var("K9_EXPAND").map_or(false, |_| true);
+    let buck_build_id_present = std::env::var("BUCK_BUILD_ID").is_ok();
+
+    if !runtime_var && buck_build_id_present {
+        // If not, we'll also check compile time variable. This is going to be the case with `buck`
+        // when env variables are passed to `rustc` but not to the actual binary (when running `buck test ...`)
+        //
+        // NOTE: using compile time vars is a bit sketchy, because technically you can compile the test suite
+        // once and re-run the compiled version multiple times in scenarious where you don't want to update
+        if option_env!("K9_EXPAND").is_some() {
             return true;
         }
     }

--- a/src/string_diff.rs
+++ b/src/string_diff.rs
@@ -9,6 +9,16 @@ pub fn colored_diff(left: &str, right: &str) -> Option<String> {
     }
 
     let lines = lines(left, right);
+    if lines.len() > 20 && !crate::config::CONFIG.expand_mode {
+        result.push_str(&collapsed_diff(lines));
+    } else {
+        result.push_str(&uncollapsed_diff(lines));
+    }
+    Some(result)
+}
+
+fn uncollapsed_diff(lines: Vec<diff::Result<&str>>) -> String {
+    let mut result = String::new();
     result.push_str("\n");
     for line in lines {
         match line {
@@ -23,5 +33,66 @@ pub fn colored_diff(left: &str, right: &str) -> Option<String> {
             }
         }
     }
-    Some(result)
+    result
+}
+
+fn collapsed_diff(lines: Vec<diff::Result<&str>>) -> String {
+    let mut result = String::new();
+    let mut less_significant_lines = String::new();
+    result.push_str("\n");
+    let mut collapsed_line_count = 0;
+    let mut padding: bool = true;
+    let mut padding_count = 0;
+    for line in lines {
+        match line {
+            Result::Left(l) => {
+                result.push_str(&less_significant_lines);
+                result.push_str(&format!("{} {}\n", "-".red(), &l.red()));
+
+                less_significant_lines = String::new();
+                collapsed_line_count = 0;
+            }
+            Result::Right(r) => {
+                result.push_str(&format!("{} {}\n", "+".green(), &r.green()));
+                collapsed_line_count = 0;
+                padding = true;
+                padding_count = 0;
+            }
+            Result::Both(l, _r) => {
+                if padding && padding_count < 2 {
+                    result.push_str(&format!("  {}\n", &l.dimmed()));
+                    padding_count += 1;
+                } else {
+                    padding = false;
+                    padding_count = 0;
+                    if count_newlines(&less_significant_lines) < 2 {
+                        less_significant_lines.push_str(&format!("  {}\n", &l.dimmed()));
+                    } else {
+                        collapsed_line_count += count_newlines(&less_significant_lines);
+                        if collapsed_line_count > 2 {
+                            // Pop previously collapsed string with newline
+                            result.truncate(result.len() - 45);
+                        }
+                        result.push_str(
+                            &format!(
+                                "{}   {} {}\n",
+                                "...".dimmed(),
+                                (collapsed_line_count).to_string().dimmed(),
+                                "lines collapsed".dimmed()
+                            )
+                            .dimmed(),
+                        );
+                        less_significant_lines = String::new();
+                        less_significant_lines.push_str(&format!("  {}\n", &l.dimmed()));
+                    }
+                }
+            }
+        }
+    }
+    result.push_str(&less_significant_lines);
+    result
+}
+
+fn count_newlines(s: &str) -> usize {
+    s.matches('\n').count()
 }

--- a/tests/assertions/equals_test.rs
+++ b/tests/assertions/equals_test.rs
@@ -140,3 +140,154 @@ Expected `Left` to equal `Right`:
 "
     );
 }
+
+#[test]
+fn collapsed_output() {
+    assert_matches_inline_snapshot!(
+        assertion_message(assert_equal!(vec![1, 2], vec![1, 3])),
+        "
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+assert_equal!(vec![1, 2], vec![1, 3]);
+
+Assertion Failure!
+
+
+Expected `Left` to equal `Right`:
+
+  [
+      1,
+-     2,
++     3,
+  ]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"
+    );
+
+    let mut v1 = generate_random_vectors(1, 30);
+    let mut v2 = generate_random_vectors(1, 30);
+    v2[2] = 98;
+    v2[25] = 98;
+    assert_matches_inline_snapshot!(
+        assertion_message(assert_equal!(v1, v2)),
+        "
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+assert_equal!(v1, v2);
+
+Assertion Failure!
+
+
+Expected `Left` to equal `Right`:
+
+  [
+      1,
+      2,
+-     3,
++     98,
+      4,
+      5,
+...   18 lines collapsed
+      24,
+      25,
+-     26,
++     98,
+      27,
+      28,
+      29,
+  ]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"
+    );
+
+    v1 = generate_random_vectors(1, 100);
+    v2 = generate_random_vectors(1, 100);
+    v2[1] = 98;
+    v2[45] = 98;
+    v2[56] = 98;
+    v2[85] = 98;
+    assert_matches_inline_snapshot!(
+        assertion_message(assert_equal!(v1, v2)),
+        "
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+assert_equal!(v1, v2);
+
+Assertion Failure!
+
+
+Expected `Left` to equal `Right`:
+
+  [
+      1,
+-     2,
++     98,
+      3,
+      4,
+...   40 lines collapsed
+      45,
+-     46,
++     98,
+      47,
+      48,
+...   6 lines collapsed
+      55,
+      56,
+-     57,
++     98,
+      58,
+      59,
+...   24 lines collapsed
+      84,
+      85,
+-     86,
++     98,
+      87,
+      88,
+...   10 lines collapsed
+      99,
+  ]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"
+    );
+
+    v1 = generate_random_vectors(1, 15);
+    v2 = generate_random_vectors(1, 15);
+    v2[1] = 98;
+    assert_matches_inline_snapshot!(
+        assertion_message(assert_equal!(v1, v2)),
+        "
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+assert_equal!(v1, v2);
+
+Assertion Failure!
+
+
+Expected `Left` to equal `Right`:
+
+  [
+      1,
+-     2,
++     98,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+  ]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"
+    );
+}
+
+fn generate_random_vectors(from: u64, to: u64) -> Vec<u64> {
+    (from..to).into_iter().collect::<Vec<_>>()
+}

--- a/tests/assertions/equals_test.rs
+++ b/tests/assertions/equals_test.rs
@@ -143,6 +143,7 @@ Expected `Left` to equal `Right`:
 
 #[test]
 fn collapsed_output() {
+    super::setup_test_env();
     assert_matches_inline_snapshot!(
         assertion_message(assert_equal!(vec![1, 2], vec![1, 3])),
         "


### PR DESCRIPTION
Implemented collapsing large difference output.

Please have a look at the code. I expect a lot of changes. :P

We can expand the output with `K9_EXPAND`.

TODO for me:
1. Add a lot of test cases.
2. Documentation.
3. Choose an appropriate color for the collapsed string.