### PR TITLE
Allow passing format arguments to assert_equals!

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -122,19 +122,20 @@ macro_rules! assert_equal {
             None,
         )
     }};
-    ($left:expr, $right:expr, $description:expr) => {{
+    ($left:expr, $right:expr, $($description:expr),*) => {{
         use $crate::__macros__::colored::*;
+        let description = format!($( $description ),*);
         let args_str = format!(
             "{}, {}, {}",
             stringify!($left).red(),
             stringify!($right).green(),
-            stringify!($description).dimmed(),
+            stringify!($( $description ),* ).dimmed(),
         );
         $crate::assertions::make_assertion(
             "assert_equal",
             args_str,
             $crate::assertions::equal::assert_equal($left, $right),
-            Some(&$description),
+            Some(&description),
         )
     }};
 }

--- a/tests/assertions/equals_test.rs
+++ b/tests/assertions/equals_test.rs
@@ -8,6 +8,8 @@ fn test_assert_equal() -> Result<()> {
     super::setup_test_env();
 
     assert!(assert_equal!(1, 1).is_none());
+    assert!(assert_equal!(1, 1, "some description").is_none());
+    assert!(assert_equal!(1, 1, "some formatted debcription {} {:?}", 1, "dogs").is_none());
     assert!(assert_equal!("lol", &String::from("lol")).is_none());
 
     assert_matches_inline_snapshot!(
@@ -123,12 +125,12 @@ Expected `[31mLeft[0m` to equal `[32mRight[0m`:
 fn with_context() {
     super::setup_test_env();
     assert_matches_inline_snapshot!(
-        assertion_message(assert_equal!(1, 2, "Expected those two things to be equal")),
-        "
+        assertion_message(assert_equal!(1, 2, "Expected {} to equal {}", 1, 2)),
+        r##"
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-assert_equal!(1, 2, \"Expected those two things to be equal\");
+assert_equal!(1, 2, "Expected {} to equal {}", 1, 2);
 
-Expected those two things to be equal
+Expected 1 to equal 2
 
 
 Expected `Left` to equal `Right`:
@@ -137,6 +139,6 @@ Expected `Left` to equal `Right`:
 + 2
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-"
+"##
     );
 }


### PR DESCRIPTION
now extra arguments passed to `assert_equals!` will be formatted using `format!()` macro under the hood.

e.g.

```rust
assert_equals!(1, 2, "{} must equal {}", 1, 2);
```
