### PR TITLE
Force colors to be enabled when running tests with buck

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -86,7 +86,6 @@ pub fn make_assertion(
     }
 }
 
-
 pub fn initialize_colors() {
     if crate::config::CONFIG.force_enable_colors {
         colored::control::set_override(true);

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -86,6 +86,13 @@ pub fn make_assertion(
     }
 }
 
+
+pub fn initialize_colors() {
+    if crate::config::CONFIG.force_enable_colors {
+        colored::control::set_override(true);
+    }
+}
+
 /// Asserts that two passed arguments are equal.
 /// panics if they are not
 ///
@@ -110,6 +117,7 @@ pub fn make_assertion(
 macro_rules! assert_equal {
     ($left:expr, $right:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}",
             stringify!($left).red(),
@@ -125,6 +133,7 @@ macro_rules! assert_equal {
     }};
     ($left:expr, $right:expr, $($description:expr),*) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let description = format!($( $description ),*);
         let args_str = format!(
             "{}, {}, {}",
@@ -154,6 +163,7 @@ macro_rules! assert_equal {
 macro_rules! assert_greater_than {
     ($left:expr, $right:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}",
             stringify!($left).red(),
@@ -168,6 +178,7 @@ macro_rules! assert_greater_than {
     }};
     ($left:expr, $right:expr, $description:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}, {}",
             stringify!($left).red(),
@@ -196,6 +207,7 @@ macro_rules! assert_greater_than {
 macro_rules! assert_greater_than_or_equal {
     ($left:expr, $right:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}",
             stringify!($left).red(),
@@ -210,6 +222,7 @@ macro_rules! assert_greater_than_or_equal {
     }};
     ($left:expr, $right:expr, $description:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}, {}",
             stringify!($left).red(),
@@ -237,6 +250,7 @@ macro_rules! assert_greater_than_or_equal {
 macro_rules! assert_lesser_than {
     ($left:expr, $right:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}",
             stringify!($left).red(),
@@ -251,6 +265,7 @@ macro_rules! assert_lesser_than {
     }};
     ($left:expr, $right:expr, $description:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}, {}",
             stringify!($left).red(),
@@ -279,6 +294,7 @@ macro_rules! assert_lesser_than {
 macro_rules! assert_lesser_than_or_equal {
     ($left:expr, $right:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}",
             stringify!($left).red(),
@@ -293,6 +309,7 @@ macro_rules! assert_lesser_than_or_equal {
     }};
     ($left:expr, $right:expr, $description:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}, {}",
             stringify!($left).red(),
@@ -322,6 +339,7 @@ macro_rules! assert_lesser_than_or_equal {
 macro_rules! assert_matches_regex {
     ($s:expr, $regex:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!("{}, {}", stringify!($s).red(), stringify!($regex).green());
         $crate::assertions::make_assertion(
             "assert_matches_regex",
@@ -332,6 +350,7 @@ macro_rules! assert_matches_regex {
     }};
     ($s:expr, $regex:expr, $description:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}, {}",
             stringify!($s).red(),
@@ -372,6 +391,7 @@ macro_rules! assert_matches_regex {
 macro_rules! assert_err_matches_regex {
     ($err:expr, $regex:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!("{}, {}", stringify!($err).red(), stringify!($regex).green(),);
         $crate::assertions::make_assertion(
             "assert_err_matches_regex",
@@ -382,6 +402,7 @@ macro_rules! assert_err_matches_regex {
     }};
     ($s:expr, $regex:expr, $context:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}, {}",
             stringify!($err).red(),
@@ -425,6 +446,7 @@ macro_rules! assert_err_matches_regex {
 macro_rules! assert_matches_snapshot {
     ($to_snap:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let line = line!();
         let column = column!();
         let file = file!();
@@ -438,6 +460,7 @@ macro_rules! assert_matches_snapshot {
     }};
     ($to_snap:expr, $description:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let line = line!();
         let column = column!();
         let file = file!();
@@ -459,6 +482,7 @@ macro_rules! assert_matches_snapshot {
 macro_rules! assert_matches_inline_snapshot {
     ($to_snap:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let line = line!();
         let column = column!();
         let file = file!();
@@ -475,6 +499,7 @@ macro_rules! assert_matches_inline_snapshot {
     }};
     ($to_snap:expr, $inline_snap:literal) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let line = line!();
         let column = column!();
         let file = file!();
@@ -511,6 +536,7 @@ macro_rules! assert_matches_inline_snapshot {
 macro_rules! assert_ok {
     ($left:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!("{}", stringify!($left).red());
         $crate::assertions::make_assertion(
             "assert_ok",
@@ -521,6 +547,7 @@ macro_rules! assert_ok {
     }};
     ($left:expr, $description:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}",
             stringify!($left).red(),
@@ -547,6 +574,7 @@ macro_rules! assert_ok {
 macro_rules! assert_err {
     ($left:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!("{}", stringify!($left).red());
         $crate::assertions::make_assertion(
             "assert_err",
@@ -557,6 +585,7 @@ macro_rules! assert_err {
     }};
     ($left:expr, $description:expr) => {{
         use $crate::__macros__::colored::*;
+        $crate::assertions::initialize_colors();
         let args_str = format!(
             "{}, {}",
             stringify!($left).red(),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -3,10 +3,8 @@ use anyhow::Result;
 use std::path::{Component, Path, PathBuf};
 
 pub fn get_project_root_path() -> PathBuf {
-    let buck_build_id_present = std::env::var("BUCK_BUILD_ID").is_ok();
-
     // If there's a buck build id we'll grab the `pwd`, because we're probably running `buck test` from the root
-    if buck_build_id_present {
+    if crate::config::CONFIG.built_with_buck {
         let pwd = std::env::var("PWD").expect(
             "
 `BUCK_BUILD_ID` enviroment variable was present, which means this project is being built with


### PR DESCRIPTION
This PR improves support for colors in output when running tests built with buck. By default the `colored` module would not produce output since it disables colors when stdout is a tty: https://github.com/mackwic/colored/blob/master/src/control.rs#L105-L114

We detect if buck is being used and if so, force colored output.
