### PR TITLE
Add qualified `use k9` test

### DIFF
--- a/k9_tests/inline_snap_test.rs
+++ b/k9_tests/inline_snap_test.rs
@@ -65,3 +65,72 @@ fn passing() {}
 
     Ok(())
 }
+
+// when using k9, users can import it with `use k9;` statement, instead of
+// `use k9::*`; then, calling `k9::assert_matches_inline_snapshot!(...)` with
+// the trailing k9.  let's make sure that using it that way works.
+#[test]
+fn inline_snapshots_qualified() -> Result<()> {
+    let p = TestProject::new();
+
+    p.write_file("Cargo.toml", crate::test_utils::TEST_CARGO_TOML)?;
+
+    p.write_file(
+        "lib.rs",
+        r#"
+#[cfg(test)]
+mod tests;
+"#,
+    )?;
+
+    p.write_file(
+        "tests.rs",
+        r#"
+use k9;
+
+#[test]
+fn inline_snapshot() {
+    k9::assert_matches_inline_snapshot!(format!("{}", std::f64::consts::E));
+}
+
+#[test]
+fn passing() {}
+    "#,
+    )?;
+
+    let runner = p.run_tests().build().unwrap();
+    let test_run = runner.run()?;
+
+    assert!(!test_run.success);
+
+    assert_matches_inline_snapshot!(
+        format!("{:?}", test_run.test_cases),
+        "{\"tests::inline_snapshot\": TestCaseResult { status: Fail }, \"tests::passing\": TestCaseResult { status: Pass }}"
+    );
+    let runner = p.run_tests().update_snapshots(true).build().unwrap();
+    let test_run = runner.run()?;
+    assert!(test_run.success);
+
+    // Inline snapshot must be updated in the source.
+    // NOTE: we're using assert_equal! so we don't test inline snapshot feature
+    // using inline snapshots macro. If it's broken, the test could be broken as well
+    // and will give false positive.
+    assert_eq!(
+        p.read_file("tests.rs")?.as_str(),
+        "use k9;
+
+#[test]
+fn inline_snapshot() {
+    k9::assert_matches_inline_snapshot!(
+        format!(\"{}\", std::f64::consts::E),
+        r##\"2.718281828459045\"##
+    );
+}
+
+#[test]
+fn passing() {}
+"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Was about to fix the use of `k9::assert_matches_inline_snapshot!` and
after writing the test realized it does work as intented so no fixing
necessary, just adding the test to make sure it keeps working.