### PR TITLE
[assert_equal!] Add temp value bindings

### DIFF
--- a/k9/src/assertions.rs
+++ b/k9/src/assertions.rs
@@ -116,8 +116,6 @@ pub fn initialize_colors() {
 #[macro_export]
 macro_rules! assert_equal {
     ($left:expr, $right:expr) => {{
-        let left = $left;
-        let right = $right;
         use $crate::__macros__::colored::*;
         $crate::assertions::initialize_colors();
         let args_str = format!(
@@ -125,13 +123,18 @@ macro_rules! assert_equal {
             stringify!($left).red(),
             stringify!($right).green(),
         );
-        let fail = &left != &right;
-        $crate::assertions::make_assertion(
-            "assert_equal",
-            args_str,
-            $crate::assertions::equal::assert_equal(left, right, fail),
-            None,
-        )
+
+        match  (&$left, &$right) {
+            (left, right) => {
+                let fail = *left != *right;
+                $crate::assertions::make_assertion(
+                    "assert_equal",
+                    args_str,
+                    $crate::assertions::equal::assert_equal(left, right, fail),
+                    None,
+                )
+            }
+        }
     }};
     ($left:expr, $right:expr, $($description:expr),*) => {{
         use $crate::__macros__::colored::*;
@@ -143,13 +146,17 @@ macro_rules! assert_equal {
             stringify!($right).green(),
             stringify!($( $description ),* ).dimmed(),
         );
-        let fail = &$left != &$right;
-        $crate::assertions::make_assertion(
-            "assert_equal",
-            args_str,
-            $crate::assertions::equal::assert_equal(&$left, &$right, fail),
-            Some(&description),
-        )
+        match  (&$left, &$right) {
+            (left, right) => {
+                let fail = *left != *right;
+                $crate::assertions::make_assertion(
+                    "assert_equal",
+                    args_str,
+                    $crate::assertions::equal::assert_equal(left, right, fail),
+                    Some(&description),
+                )
+            }
+        }
     }};
 }
 

--- a/k9_tests/Cargo.toml
+++ b/k9_tests/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.34"
 derive_builder = "0.9.0"
 fs_extra = "1.2.0"
 k9_released = { version = "*", package = "k9" }
+k9_local = { path = "../k9", package = "k9" }
 lazy_static = "1.4.0"
 regex = "1.4.2"
 

--- a/k9_tests/inline_snap_test.rs
+++ b/k9_tests/inline_snap_test.rs
@@ -28,7 +28,7 @@ fn inline_snapshot() {
 
 #[test]
 fn passing() {}
-    "#,
+"#,
     )?;
 
     let runner = p.run_tests().build().unwrap();
@@ -44,13 +44,7 @@ fn passing() {}
     let test_run = runner.run()?;
     assert!(test_run.success);
 
-    // Inline snapshot must be updated in the source.
-    // NOTE: we're using assert_equal! so we don't test inline snapshot feature
-    // using inline snapshots macro. If it's broken, the test could be broken as well
-    // and will give false positive.
-    k9_released::assert_equal!(
-        p.read_file("basic_tests.rs")?.as_str(),
-        "use k9::*;
+    let expected = "use k9::*;
 
 #[test]
 fn inline_snapshot() {
@@ -63,8 +57,19 @@ fn inline_snapshot() {
 
 #[test]
 fn passing() {}
-"
+";
+
+    // Inline snapshot must be updated in the source.
+    // NOTE: we're using assert_equal! so we don't test inline snapshot feature
+    // using inline snapshots macro. If it's broken, the test could be broken as well
+    // and will give false positive.
+    k9_local::assert_equal!(
+        k9_local::MultilineString::new(p.read_file("basic_tests.rs")?.as_str()),
+        k9_local::MultilineString::new(expected)
     );
+    k9_local::assert_equal!(p.read_file("basic_tests.rs")?.as_str(), expected);
+    k9_released::assert_equal!(p.read_file("basic_tests.rs")?.as_str(), expected);
+    assert_eq!(p.read_file("basic_tests.rs")?.as_str(), expected);
 
     Ok(())
 }


### PR DESCRIPTION
If an expression that returns a reference is passed in to the macro it will fail compiling because the value would be dropped at the end of the statement. Adding a temp wrapping match to bind values before doing any processing 


Error before that was caught by CI
```
  --> k9_tests/inline_snap_test.rs:52:9
   |
51 | /     k9_released::assert_equal!(
52 | |         p.read_file("basic_tests.rs")?.as_str(),
   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
53 | |         "use k9::*;
54 | |
...  |
66 | | "
67 | |     );
   | |      -
   | |      |
   | |______temporary value is freed at the end of this statement
   |        borrow later used here
   |
   = note: consider using a `let` binding to create a longer lived value
```