### PR TITLE
Rustc@1.51.0

### DIFF
--- a/k9/Cargo.toml
+++ b/k9/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k9"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Aaron Abramov <aaron@abramov.io>"]
 edition = "2018"
 description = "rust testing library"

--- a/k9/Cargo.toml
+++ b/k9/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k9"
-version = "0.10.4"
+version = "0.11.0"
 authors = ["Aaron Abramov <aaron@abramov.io>"]
 edition = "2018"
 description = "rust testing library"

--- a/k9/src/assertions.rs
+++ b/k9/src/assertions.rs
@@ -71,7 +71,7 @@ macro_rules! make_assertion {
         );
         if let Some(assertion) = &assertion {
             if $crate::config::should_panic() {
-                panic!(assertion.get_failure_message());
+                panic!("{}", assertion.get_failure_message());
             }
         }
         assertion

--- a/k9/tests/assertions/err_matches_regex_test.rs
+++ b/k9/tests/assertions/err_matches_regex_test.rs
@@ -12,7 +12,7 @@ fn test() -> Result<()> {
         .expect("must fail")
         .get_failure_message();
 
-    assert_matches_snapshot!(err).map(|a| panic!(a));
+    assert_matches_snapshot!(err).map(|a| panic!("{:?}", a));
     Ok(())
 }
 
@@ -24,5 +24,5 @@ fn test_when_ok() {
         .expect("must_fail")
         .get_failure_message();
 
-    assert_matches_snapshot!(err).map(|a| panic!(a));
+    assert_matches_snapshot!(err).map(|a| panic!("{:?}", a));
 }

--- a/k9/tests/assertions/err_test.rs
+++ b/k9/tests/assertions/err_test.rs
@@ -15,7 +15,7 @@ fn test_assert_err() -> Result<()> {
     let failure_message = assert_err!(Ok([1, 2, 3]))
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(failure_message).map(|a| panic!(a));
+    assert_matches_snapshot!(failure_message).map(|a| panic!("{:?}", a));
     Ok(())
 }
 
@@ -25,5 +25,5 @@ fn with_context() {
     let err = assert_err!(Ok(1), "Expected Value to be Err(T)")
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(err).map(|a| panic!(a));
+    assert_matches_snapshot!(err).map(|a| panic!("{:?}", a));
 }

--- a/k9/tests/assertions/greater_than_or_equal_test.rs
+++ b/k9/tests/assertions/greater_than_or_equal_test.rs
@@ -6,7 +6,7 @@ use k9::assert_greater_than_or_equal;
 fn test_assert_greater_than_or_equal() -> Result<()> {
     super::setup_test_env();
 
-    assert_greater_than_or_equal!(2, 1).map(|a| panic!(a));
+    assert_greater_than_or_equal!(2, 1).map(|a| panic!("{:?}", a));
     assert!(assert_greater_than_or_equal!(1, 1).is_none());
     assert!(assert_greater_than_or_equal!(0, 1).is_some());
     assert!(assert_greater_than_or_equal!("234", "cde").is_some());

--- a/k9/tests/assertions/greater_than_test.rs
+++ b/k9/tests/assertions/greater_than_test.rs
@@ -5,7 +5,7 @@ use k9::{assert_greater_than, assert_matches_snapshot};
 fn test_assert_greater_than() -> Result<()> {
     super::setup_test_env();
 
-    assert_greater_than!(2, 1).map(|a| panic!(a));
+    assert_greater_than!(2, 1).map(|a| panic!("{:?}", a));
     assert!(assert_greater_than!(1, 1).is_some());
     assert!(assert_greater_than!(0, 1).is_some());
     assert!(assert_greater_than!("234", "cde").is_some());
@@ -14,7 +14,7 @@ fn test_assert_greater_than() -> Result<()> {
     let failure_message = assert_greater_than!(1, 2)
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(failure_message).map(|a| panic!(a));
+    assert_matches_snapshot!(failure_message).map(|a| panic!("{:?}", a));
 
     assert!(assert_greater_than!(9.8, 3.15, "Expected left to be greater than right").is_none());
     Ok(())
@@ -26,5 +26,5 @@ fn with_context() {
     let err = assert_greater_than!(1, 2, "Expected left to be greater than right")
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(err).map(|a| panic!(a));
+    assert_matches_snapshot!(err).map(|a| panic!("{:?}", a));
 }

--- a/k9/tests/assertions/lesser_than_or_equal_test.rs
+++ b/k9/tests/assertions/lesser_than_or_equal_test.rs
@@ -5,7 +5,7 @@ use k9::{assert_lesser_than_or_equal, assert_matches_snapshot};
 fn test_assert_lesser_than_or_equal() -> Result<()> {
     super::setup_test_env();
 
-    assert_lesser_than_or_equal!(1, 2).map(|a| panic!(a));
+    assert_lesser_than_or_equal!(1, 2).map(|a| panic!("{:?}", a));
     assert!(assert_lesser_than_or_equal!(1, 1).is_none());
     assert!(assert_lesser_than_or_equal!(1, 0).is_some());
     assert!(assert_lesser_than_or_equal!("cde", "234").is_some());
@@ -18,7 +18,7 @@ fn test_assert_lesser_than_or_equal() -> Result<()> {
     let failure_message = assert_lesser_than_or_equal!(2, 1)
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(failure_message).map(|a| panic!(a));
+    assert_matches_snapshot!(failure_message).map(|a| panic!("{:?}", a));
 
     assert!(assert_lesser_than_or_equal!(
         3.15,
@@ -35,5 +35,5 @@ fn with_context() {
     let err = assert_lesser_than_or_equal!(2, 1, "Expected left to lesser than or equal to right")
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(err).map(|a| panic!(a));
+    assert_matches_snapshot!(err).map(|a| panic!("{:?}", a));
 }

--- a/k9/tests/assertions/lesser_than_test.rs
+++ b/k9/tests/assertions/lesser_than_test.rs
@@ -5,7 +5,7 @@ use k9::{assert_lesser_than, assert_matches_snapshot};
 fn test_assert_lesser_than() -> Result<()> {
     super::setup_test_env();
 
-    assert_lesser_than!(1, 2).map(|a| panic!(a));
+    assert_lesser_than!(1, 2).map(|a| panic!("{:?}", a));
     assert!(assert_lesser_than!(1, 1).is_some());
     assert!(assert_lesser_than!(1, 0).is_some());
     assert!(assert_lesser_than!("cde", "234").is_some());
@@ -14,7 +14,7 @@ fn test_assert_lesser_than() -> Result<()> {
     let failure_message = assert_lesser_than!(2, 1)
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(failure_message).map(|a| panic!(a));
+    assert_matches_snapshot!(failure_message).map(|a| panic!("{:?}", a));
 
     assert!(assert_lesser_than!(3.15, 9.8, "Expected left to be lesser than right").is_none());
     Ok(())
@@ -26,5 +26,5 @@ fn with_context() {
     let err = assert_lesser_than!(2, 1, "Expected left to be lesser than right")
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(err).map(|a| panic!(a));
+    assert_matches_snapshot!(err).map(|a| panic!("{:?}", a));
 }

--- a/k9/tests/assertions/matches_regex_test.rs
+++ b/k9/tests/assertions/matches_regex_test.rs
@@ -11,6 +11,6 @@ fn test_assert_equal() -> Result<()> {
         .expect("must fail")
         .get_failure_message();
 
-    assert_matches_snapshot!(err).map(|a| panic!(a));
+    assert_matches_snapshot!(err).map(|a| panic!("{:?}", a));
     Ok(())
 }

--- a/k9/tests/assertions/ok_test.rs
+++ b/k9/tests/assertions/ok_test.rs
@@ -21,7 +21,7 @@ fn test_assert_ok() -> Result<()> {
     let failure_message = assert_ok!(Err("Parsing Error"))
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(failure_message).map(|a| panic!(a));
+    assert_matches_snapshot!(failure_message).map(|a| panic!("{:?}", a));
     Ok(())
 }
 
@@ -31,5 +31,5 @@ fn with_context() {
     let err = assert_ok!(Err("Version Mismatch!"), "Expected Value to be Ok(T)")
         .expect("must fail")
         .get_failure_message();
-    assert_matches_snapshot!(err).map(|a| panic!(a));
+    assert_matches_snapshot!(err).map(|a| panic!("{:?}", a));
 }

--- a/k9/tests/mod.rs
+++ b/k9/tests/mod.rs
@@ -5,7 +5,7 @@ mod assertions;
 #[macro_export]
 macro_rules! assert_matches_inline_snapshot {
     ( $( $arg:expr ),* ) => {{
-        k9::assert_matches_inline_snapshot!( $( $arg ),* ).map(|a| panic!(a))
+        k9::assert_matches_inline_snapshot!( $( $arg ),* ).map(|a| panic!("{:?}", a))
     }};
 }
 


### PR DESCRIPTION
`panic!()` no longer accept non string literals. Adding a fix to make it work with the latest nightly