### PR TITLE
Migrate from term_size to terminal_size.

### DIFF
--- a/k9/Cargo.toml
+++ b/k9/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2"
 proc-macro2 = { version = "1.0", default-features = false, features= ["span-locations"] }
 regex = { version = "1.3", optional = true }
 syn = { version = "1.0", features = ["full", "extra-traits", "visit"] }
-term_size = "0.3"
+terminal_size = "0.2"
 anyhow = "1.0.32"
 
 [dev-dependencies]

--- a/k9/src/utils.rs
+++ b/k9/src/utils.rs
@@ -6,8 +6,8 @@ pub fn terminal_separator_line() -> String {
     let width_override = crate::config::terminal_width_override();
     let width = if width_override != 0 {
         width_override
-    } else if let Some((width, _)) = term_size::dimensions() {
-        width
+    } else if let Some((width, _)) = terminal_size::terminal_size() {
+        width.0 as usize
     } else {
         100 // default width if we can't determine terminal width
     };


### PR DESCRIPTION
The [`term_size`] crate is no longer maintained, and behaves incorrectly
[on PowerPC]. This patch migrates k9 to the [`terminal_size`] crate
instead.

[`term_size`]: https://crates.io/crates/term_size
[`terminal_size`]: https://crates.io/crates/terminal_size
[on PowerPC]: https://github.com/ogham/exa/issues/400
