### PR TITLE
Update `colored` dependency to version 2

### DIFF
--- a/k9/Cargo.toml
+++ b/k9/Cargo.toml
@@ -15,7 +15,7 @@ default = ["regex"]
 custom_comparison_formatters = []
 
 [dependencies]
-colored = "1.9"
+colored = "2"
 diff = "0.1"
 lazy_static = "1.4"
 libc = "0.2"


### PR DESCRIPTION
`colored` appears in the public API of k9, for example here: https://docs.rs/k9/0.11.6/k9/config/fn.update_instructions.html

Version 1.9 is 3.5 years outdated at this point. Updating to version 2 in k9 avoids forcing the downstream code to stick to a 3.5 year old version of the dependency lacking any of the recent improvements.

Changelog: https://github.com/colored-rs/colored/blob/master/CHANGELOG.md

