### PR TITLE
Update test snapshots for Rust 1.73+'s panic formatting

### DIFF
--- a/k9_tests/basic_fixture.rs
+++ b/k9_tests/basic_fixture.rs
@@ -46,7 +46,8 @@ test snapshots_experimental::experimental_snapshot ... FAILED
 failures:
 
 ---- snapshots_experimental::experimental_snapshot stdout ----
-thread 'snapshots_experimental::experimental_snapshot' panicked at '
+thread 'snapshots_experimental::experimental_snapshot' panicked at _tests/snapshots_experimental.rs:16:5:
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 snapshot!(map);
 
@@ -71,7 +72,7 @@ Received value:
 run with `K9_UPDATE_SNAPSHOTS=1` to update/create snapshots
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-', _tests/snapshots_experimental.rs:16:5
+
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 

--- a/k9_tests/failure_messages.rs
+++ b/k9_tests/failure_messages.rs
@@ -52,7 +52,8 @@ test assert_equal_basic ... FAILED
 failures:
 
 ---- assert_equal_basic stdout ----
-thread 'assert_equal_basic' panicked at '
+thread 'assert_equal_basic' panicked at _tests/mod.rs:5:5:
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 assert_equal!(1, 2);
 
@@ -65,7 +66,7 @@ Expected `Left` to equal `Right`:
 + 2
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-', _tests/mod.rs:5:5
+
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
@@ -97,7 +98,8 @@ test assert_equal_multiline_string ... FAILED
 failures:
 
 ---- assert_equal_multiline_string stdout ----
-thread 'assert_equal_multiline_string' panicked at '
+thread 'assert_equal_multiline_string' panicked at _tests/mod.rs:10:5:
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 assert_equal!("hello\
 world", "hello\
@@ -114,7 +116,7 @@ world"
 how are you?"
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-', _tests/mod.rs:10:5
+
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
@@ -146,7 +148,8 @@ test snapshot_basic ... FAILED
 failures:
 
 ---- snapshot_basic stdout ----
-thread 'snapshot_basic' panicked at '
+thread 'snapshot_basic' panicked at _tests/mod.rs:15:5:
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 snapshot!("a");
 
@@ -162,7 +165,7 @@ a
 run with `K9_UPDATE_SNAPSHOTS=1` to update/create snapshots
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-', _tests/mod.rs:15:5
+
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 


### PR DESCRIPTION
The messages change due to https://github.com/rust-lang/rust/pull/112849.