### PR TITLE
Fix unused_imports warning in test

### DIFF
--- a/k9_tests/support/mod.rs
+++ b/k9_tests/support/mod.rs
@@ -2,7 +2,7 @@ mod test_project;
 mod test_run;
 
 pub use test_project::TestProject;
-pub use test_run::{TestRun, TestRunResult, _TestRunBuilder as TestRunBuilder};
+pub use test_run::{TestRunResult, _TestRunBuilder as TestRunBuilder};
 
 pub const TEST_CARGO_TOML: &str = r#"
 [workspace]


### PR DESCRIPTION
```console
warning: unused import: `TestRun`
 --> k9_tests/support/mod.rs:5:20
  |
5 | pub use test_run::{TestRun, TestRunResult, _TestRunBuilder as TestRunBuilder};
  |                    ^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```