### PR TITLE
avoid failure when there is trailing comma

### DIFF
--- a/k9/src/assertions.rs
+++ b/k9/src/assertions.rs
@@ -162,7 +162,7 @@ macro_rules! assert_equal {
             }
         }
     }};
-    ($left:expr, $right:expr, $($description:expr),*) => {{
+    ($left:expr, $right:expr, $($description:expr),* $(,)?) => {{
         use $crate::__macros__::colored::*;
         $crate::assertions::initialize_colors();
         let description = format!($( $description ),*);


### PR DESCRIPTION
Hi @boujeepossum,

I added support for trailing commas in the `assert_equal!` macro to ensure tests don't fail when rustfmt adds that.

For all I know, this change does not affect existing k9 users.

Thanks for making k9!